### PR TITLE
Use pretend-reqwest as HttpClient

### DIFF
--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -12,12 +12,13 @@ keywords = ["acfun", "live"]
 
 [features]
 default = ["default_http_client"]
-default_http_client = ["reqwest"]
+default_http_client = ["reqwest", "pretend-reqwest"]
 
 [dependencies]
 async-trait = "0.1.51"
 cookie = "0.15.1"
-pretend = "0.2.2"
+pretend = "0.3.0"
+pretend-reqwest = { version = "0.3.0", optional = true, default-features = false }
 reqwest = { version = "0.11.4", default-features = false, features = ["rustls-tls", "gzip"], optional = true }
 serde = { version = "1.0.127", features = ["derive"] }
 serde_json = "1.0.66"

--- a/api/src/acfun.rs
+++ b/api/src/acfun.rs
@@ -1,5 +1,5 @@
 use crate::response::*;
-use pretend::{header, pretend, request, Json, Response, Result};
+use pretend::{pretend, Json, Response, Result};
 use serde::Serialize;
 
 #[derive(Clone, Debug, Serialize)]

--- a/api/src/client.rs
+++ b/api/src/client.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 
 #[cfg(feature = "default_http_client")]
-use crate::http::HttpClient;
+use crate::http::{new_http_client, HttpClient};
 
 const ACFUN_ID: &str = "https://id.app.acfun.cn/";
 const ACFUN_LIVE: &str = "https://live.acfun.cn/";
@@ -45,7 +45,7 @@ impl<C: Clone> Clients<C> {
 impl Clients<HttpClient> {
     #[inline]
     fn default_clients() -> Result<Self> {
-        Self::new(HttpClient::default_client()?)
+        Self::new(new_http_client()?)
     }
 }
 

--- a/api/src/http.rs
+++ b/api/src/http.rs
@@ -1,13 +1,7 @@
 use crate::Result;
-use async_trait::async_trait;
-use pretend::{
-    client::{Bytes, Client, Method},
-    Error, HeaderMap, Response, Result as PretendResult, Url,
-};
-use std::{
-    ops::{Deref, DerefMut},
-    time::Duration,
-};
+use std::time::Duration;
+
+pub use pretend_reqwest::Client as HttpClient;
 
 const TIMEOUT: Duration = Duration::from_secs(10);
 const IDLE_TIMEOUT: Duration = Duration::from_secs(90);
@@ -26,81 +20,6 @@ fn default_reqwest_client() -> Result<reqwest::Client> {
         .build()?)
 }
 
-#[derive(Clone, Debug)]
-pub struct HttpClient(reqwest::Client);
-
-impl HttpClient {
-    #[inline]
-    pub const fn new(client: reqwest::Client) -> Self {
-        Self(client)
-    }
-
-    #[inline]
-    pub fn default_client() -> Result<Self> {
-        Ok(Self(default_reqwest_client()?))
-    }
-}
-
-// https://github.com/SfietKonstantin/pretend/blob/main/pretend-reqwest/src/lib.rs
-#[async_trait]
-impl Client for HttpClient {
-    async fn execute(
-        &self,
-        method: Method,
-        url: Url,
-        headers: HeaderMap,
-        body: Option<Bytes>,
-    ) -> PretendResult<Response<Bytes>> {
-        let mut builder = self.request(method, url).headers(headers);
-        if let Some(body) = body {
-            builder = builder.body(body);
-        }
-        let response = builder.send().await;
-        let mut response = response.map_err(|err| Error::Response(Box::new(err)))?;
-
-        let status = response.status();
-        let headers = std::mem::take(response.headers_mut());
-
-        let bytes = response.bytes().await;
-        let bytes = bytes.map_err(|err| Error::Body(Box::new(err)))?;
-
-        Ok(Response::new(status, headers, bytes))
-    }
-}
-
-impl Default for HttpClient {
-    #[inline]
-    fn default() -> Self {
-        Self::default_client().expect("failed to build default reqwest client")
-    }
-}
-
-impl AsRef<reqwest::Client> for HttpClient {
-    #[inline]
-    fn as_ref(&self) -> &reqwest::Client {
-        &self.0
-    }
-}
-
-impl AsMut<reqwest::Client> for HttpClient {
-    #[inline]
-    fn as_mut(&mut self) -> &mut reqwest::Client {
-        &mut self.0
-    }
-}
-
-impl Deref for HttpClient {
-    type Target = reqwest::Client;
-
-    #[inline]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl DerefMut for HttpClient {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
+pub fn new_http_client() -> Result<HttpClient> {
+    Ok(HttpClient::new(default_reqwest_client()?))
 }

--- a/api/src/kuaishou.rs
+++ b/api/src/kuaishou.rs
@@ -1,5 +1,5 @@
 use crate::response::*;
-use pretend::{header, pretend, request, Json, Result};
+use pretend::{pretend, Json, Result};
 use serde::Serialize;
 use std::collections::HashMap;
 


### PR DESCRIPTION
This commit uses pretend-reqwest as HttpClient
instead of reimplementing it.